### PR TITLE
Update header.tex: package scrpage2 obsolete.

### DIFF
--- a/header.tex
+++ b/header.tex
@@ -1,3 +1,5 @@
+% \RequirePackage{scrlfile}
+% \ReplacePackage{scrpage2}{scrlayer-scrpage}
 \documentclass[fontsize=12pt, paper=a4, headinclude, twoside=false, parskip=half+, pagesize=auto, numbers=noenddot, plainheadsepline, open=right, toc=listof, toc=bibliography]{scrreprt}
 % Abstand über Chapter Überschrift verringern
 \renewcommand*{\chapterheadstartvskip}{\vspace*{-10pt}}
@@ -5,7 +7,8 @@
 \pdfminorversion=5
 \pdfobjcompresslevel=1
 % Allgemeines
-\usepackage[automark]{scrpage2} % Kopf- und Fußzeilen
+% \usepackage[automark]{scrpage2} % Kopf- und Fußzeilen
+\usepackage[automark]{scrlayer-scrpage}
 \usepackage{amsmath} % Mathesachen
 \newtheorem{definition}{Definition}
 \usepackage[T1]{fontenc} % Ligaturen, richtige Umlaute im PDF


### PR DESCRIPTION
Dear Dr. Kreutzer,

Thank you for sharing the template with us!

It appears that the package `scrpage2` is obsolete, in which case `header.tex` now throws an error during compilation:

`LaTeX Error: File scrpage2.sty not found.`

it requires a minor update to fix the error

```
\usepackage[<options>]{scrpage2}
```

need to be replaced with 

```
\usepackage[<options>]{scrlayer-scrpage}
```

issue: https://tex.stackexchange.com/questions/541766/latex-error-file-scrpage2-sty-not-found

Kind regards,
Jinghua